### PR TITLE
Configure exec-maven-plugin in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,14 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.example.Converter</mainClass>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
The command 'mvn exec:java -Dexec.mainClass="com.example.Converter"' was failing on PowerShell due to argument parsing issues.

This change adds the exec-maven-plugin to the pom.xml and sets the mainClass configuration. This simplifies the execution command to 'mvn exec:java' and makes it more robust across different shell environments.